### PR TITLE
Per-repo branch overrides, --version flag, and cross-platform release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.4'
+          cache: true   # <-- boolean, not string
+
+      - name: Install dependencies
+        run: |
+          make install
+          go mod tidy
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,20 @@
-name: Go
+name: Release
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
 
     steps:
       - name: Checkout code
@@ -18,12 +24,41 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22.4'
-          cache: true   # <-- boolean, not string
+          cache: true
 
-      - name: Install dependencies
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
         run: |
-          make install
-          go mod tidy
+          ext=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            ext=".exe"
+          fi
+          name="rp_${{ matrix.goos }}_${{ matrix.goarch }}${ext}"
+          go build -ldflags "-X main.Version=${{ github.ref_name }}" -o "$name" .
+          echo "ARTIFACT=$name" >> "$GITHUB_ENV"
 
-      - name: Run tests
-        run: make test
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: ${{ env.ARTIFACT }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: artifacts/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+/rp
+/reporter
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 DEFAULT_GOAL: help
 
+VERSION ?= v0.0.1
+
 install: ;@ ## Install Setup
 	@./scripts/install_dev.sh
 .PHONY: install
@@ -18,7 +20,7 @@ test: fmt lint ;@ ## Run Tests
 .PHONY: test
 
 build: ;@ ## Run Build
-	@go build -o rp ./...
+	@go build -ldflags "-X main.Version=$(VERSION)" -o rp .
 .PHONY: build
 
 help:

--- a/README.md
+++ b/README.md
@@ -34,12 +34,41 @@ Reporter recursively reports and resolves drifts across multiple git repositorie
 Options:
   --explain, -e     Show examples
   --help, -h        Show this help message
+  --version, -v     Show version information
   --update, -u      Automatically update repositories that are behind
   --branch, -b      Specify the branch to check (default: main)
   --log, -l         Show the complete list of changes using git log
   --force, -f       Forcefully abort rebase and merge conflicts to update
   --remote, -r      Remote name (default: origin)
+
+Config file (.rprc) also supports a 'branches' map to override the branch
+checked per-repository, keyed by directory name:
+
+  branches:
+    repo1: release
+    repo2: develop
 ```
+
+## Releases
+
+Prebuilt binaries for Linux, macOS, and Windows (amd64/arm64) are published on the
+[GitHub Releases](https://github.com/devpies/reporter/releases) page for every `vX.Y.Z` tag. Download the archive for
+your platform, and verify the build with:
+
+```sh
+rp --version
+```
+
+Maintainers cut a release by pushing a tag matching `v*`:
+
+```sh
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+This triggers the `Release` GitHub Actions workflow, which cross-builds `rp` for every supported platform and
+publishes a GitHub Release with the binaries attached and auto-generated notes listing the changes since the
+previous release.
 
 ## Installation
 ### Prerequisites
@@ -120,6 +149,27 @@ exclude:
    - repo3
 remote_name: origin
 ```
+
+### Per-Repository Branch Overrides
+
+By default, every repository is checked against the same `branch`. If you need specific repositories to track a
+different branch, add a `branches` map keyed by repository directory name.
+
+- **Precedence:** A per-repo entry in `branches` overrides the global `branch` for that repository.
+- **CLI override:** Explicitly passing `--branch`/`-b` on the command line takes precedence over both the global
+`branch` and any `branches` entries, applying to every repository checked.
+
+Example `.rprc` File
+
+```yaml
+branch: main
+branches:
+   repo1: release
+   repo2: develop
+```
+
+In this example, `repo1` is checked against `release`, `repo2` against `develop`, and every other repository against
+the global `main` branch.
 
 ## Contributing
 

--- a/check.go
+++ b/check.go
@@ -6,6 +6,18 @@ import (
 	"sync"
 )
 
+// resolveBranch returns the branch to check for a given repo, applying any
+// per-repo override in cfg.Branches unless the branch was explicitly set on
+// the command line, in which case the CLI value wins for every repo.
+func resolveBranch(cfg Config, repoName string) string {
+	if !cfg.BranchExplicit {
+		if repoBranch, ok := cfg.Branches[repoName]; ok {
+			return repoBranch
+		}
+	}
+	return cfg.Branch
+}
+
 // checkIfBehind checks if the local branch is behind the remote branch.
 func checkIfBehind(dir string, wg *sync.WaitGroup, results chan<- string, cfg Config) bool {
 	defer wg.Done()
@@ -22,7 +34,10 @@ func checkIfBehind(dir string, wg *sync.WaitGroup, results chan<- string, cfg Co
 		return false
 	}
 
-	g := NewGitExecutor(cfg, gitRoot, filepath.Base(gitRoot))
+	repoName := filepath.Base(gitRoot)
+	cfg.Branch = resolveBranch(cfg, repoName)
+
+	g := NewGitExecutor(cfg, gitRoot, repoName)
 
 	// Check if the remote exists.
 	if !g.hasRemoteURL() {

--- a/check_test.go
+++ b/check_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveBranch(t *testing.T) {
+	cfg := Config{
+		Branch: "main",
+		Branches: map[string]string{
+			"repoA": "release",
+		},
+	}
+
+	// Per-repo override applies when no CLI flag given.
+	assert.Equal(t, "release", resolveBranch(cfg, "repoA"), "Expected per-repo override for repoA")
+
+	// Global branch used when repo has no entry.
+	assert.Equal(t, "main", resolveBranch(cfg, "repoB"), "Expected global branch for repoB")
+
+	// CLI-provided branch wins over a per-repo entry.
+	cfg.Branch = "develop"
+	cfg.BranchExplicit = true
+	assert.Equal(t, "develop", resolveBranch(cfg, "repoA"), "Expected explicit CLI branch to win over per-repo override")
+}

--- a/config.go
+++ b/config.go
@@ -10,6 +10,9 @@
 //		exclude:
 //		- repo3
 //		remote_name: origin
+//		branches:
+//		  repo1: release
+//		  repo2: develop
 //	```
 //
 // You may place this file wherever you'd like to run reporter.
@@ -27,15 +30,18 @@ import (
 
 // Config holds configuration values.
 type Config struct {
-	Branch     string   `yaml:"branch"`
-	Update     bool     `yaml:"update"`
-	Include    []string `yaml:"include"`
-	Exclude    []string `yaml:"exclude"`
-	Force      bool     `yaml:"force"`
-	RemoteName string   `yaml:"remote_name"`
-	Log        bool
-	Help       bool
-	Explain    bool
+	Branch         string            `yaml:"branch"`
+	Update         bool              `yaml:"update"`
+	Include        []string          `yaml:"include"`
+	Exclude        []string          `yaml:"exclude"`
+	Force          bool              `yaml:"force"`
+	RemoteName     string            `yaml:"remote_name"`
+	Branches       map[string]string `yaml:"branches"`
+	Log            bool
+	Help           bool
+	Explain        bool
+	Version        bool
+	BranchExplicit bool
 }
 
 // loadConfig reads the config file.
@@ -66,6 +72,7 @@ func loadConfig(configPath string) (Config, error) {
 		"exclude":     true,
 		"force":       true,
 		"remote_name": true,
+		"branches":    true,
 	}
 	// Deserialize data into convenient map for key checking.
 	var rawConfig map[string]any
@@ -130,6 +137,8 @@ func parseFlags(args []string) (Config, error) {
 	helpShort := fs.Bool("h", false, "Show this help message (short)")
 	explain := fs.Bool("explain", false, "Show examples")
 	explainShort := fs.Bool("e", false, "Show examples (short)")
+	version := fs.Bool("version", false, "Show version information")
+	versionShort := fs.Bool("v", false, "Show version information (short)")
 	update := fs.Bool("update", false, "Automatically update repositories that are behind")
 	updateShort := fs.Bool("u", false, "Automatically update repositories that are behind (short)")
 	branch := fs.String("branch", DefaultBranch, "Specify the branch to check")
@@ -145,6 +154,15 @@ func parseFlags(args []string) (Config, error) {
 		return cfg, err
 	}
 
+	// Track whether the branch flag was explicitly passed on the command line,
+	// so per-repo branch overrides in .rprc can be distinguished from an
+	// explicit CLI request that should apply globally.
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "branch" || f.Name == "b" {
+			cfg.BranchExplicit = true
+		}
+	})
+
 	// Override config with command line flags
 	if *help {
 		cfg.Help = *help
@@ -158,6 +176,13 @@ func parseFlags(args []string) (Config, error) {
 	}
 	if *explainShort {
 		cfg.Explain = *explainShort
+	}
+
+	if *version {
+		cfg.Version = *version
+	}
+	if *versionShort {
+		cfg.Version = *versionShort
 	}
 
 	if *log {

--- a/config_test.go
+++ b/config_test.go
@@ -96,6 +96,26 @@ func TestParseFlags(t *testing.T) {
 			err: nil,
 		},
 		{
+			name: "-v",
+			args: []string{"-v"},
+			want: Config{
+				Branch:     "main",
+				RemoteName: "origin",
+				Version:    true,
+			},
+			err: nil,
+		},
+		{
+			name: "--version",
+			args: []string{"--version"},
+			want: Config{
+				Branch:     "main",
+				RemoteName: "origin",
+				Version:    true,
+			},
+			err: nil,
+		},
+		{
 			name: "-u",
 			args: []string{"-u"},
 			want: Config{
@@ -158,8 +178,9 @@ func TestParseFlags(t *testing.T) {
 			name: "-b",
 			args: []string{"-b", "test"},
 			want: Config{
-				Branch:     "test",
-				RemoteName: "origin",
+				Branch:         "test",
+				RemoteName:     "origin",
+				BranchExplicit: true,
 			},
 			err: nil,
 		},
@@ -167,8 +188,9 @@ func TestParseFlags(t *testing.T) {
 			name: "--branch",
 			args: []string{"--branch", "test"},
 			want: Config{
-				Branch:     "test",
-				RemoteName: "origin",
+				Branch:         "test",
+				RemoteName:     "origin",
+				BranchExplicit: true,
 			},
 			err: nil,
 		},
@@ -206,6 +228,9 @@ exclude:
  - repo3
 force: true
 remote_name: upstream
+branches:
+  repo1: release
+  repo2: hotfix
 `
 
 	// Write the sample config content to the file.
@@ -223,6 +248,7 @@ remote_name: upstream
 	assert.ElementsMatch(t, []string{"repo3"}, config.Exclude, "Expected exclude to match")
 	assert.True(t, config.Force, "Expected force to be true")
 	assert.Equal(t, "upstream", config.RemoteName, "Expected remote name to be 'upstream'")
+	assert.Equal(t, map[string]string{"repo1": "release", "repo2": "hotfix"}, config.Branches, "Expected branches map to match")
 }
 
 func TestFindConfigFile(t *testing.T) {
@@ -268,6 +294,7 @@ func TestValidateKeys(t *testing.T) {
 		"exclude":     true,
 		"force":       true,
 		"remote_name": true,
+		"branches":    true,
 	}
 
 	// Test with all valid keys
@@ -278,6 +305,7 @@ func TestValidateKeys(t *testing.T) {
 		"exclude":     []string{"repo2"},
 		"force":       false,
 		"remote_name": "origin",
+		"branches":    map[string]string{"repo1": "release"},
 	}
 	err := validateKeys(config, validKeys)
 	assert.NoError(t, err, "Expected no error with all valid keys")

--- a/reporter.go
+++ b/reporter.go
@@ -47,6 +47,7 @@ func main() {
 		cfg.Update = loadedConfig.Update
 		cfg.Include = loadedConfig.Include
 		cfg.Exclude = loadedConfig.Exclude
+		cfg.Branches = loadedConfig.Branches
 		if loadedConfig.RemoteName != "" {
 			cfg.RemoteName = loadedConfig.RemoteName
 		}
@@ -62,11 +63,16 @@ func main() {
 		showExamples()
 		return
 	}
+	if cliConfig.Version {
+		fmt.Println(Version)
+		return
+	}
 
 	// CLI overrides
 	if cliConfig.Branch != "" {
 		cfg.Branch = cliConfig.Branch
 	}
+	cfg.BranchExplicit = cliConfig.BranchExplicit
 	if cliConfig.RemoteName != "" {
 		cfg.RemoteName = cliConfig.RemoteName
 	}

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -8,12 +8,18 @@ set -euo pipefail
 #
 # It is intentionally designed to install the *latest available* versions every
 # time it is executed:
-#   - On Linux, Go is installed via apt and golangci-lint via the official install script.
+#   - On Linux, Go is installed via apt and golangci-lint via `go install`.
 #   - On macOS, Go and golangci-lint are installed via Homebrew.
 #
 # If the latest version is already present, the package managers will perform
 # no action (Linux apt / Homebrew). On Linux, golangci-lint will always be
-# reinstalled to ensure it matches the latest GitHub release.
+# reinstalled to ensure it matches the latest release.
+#
+# NOTE: golangci-lint's official curl-piped install.sh script was previously used
+# on Linux, but its release-asset checksum verification has been unreliable
+# (deterministic checksum mismatches against the published release tarball).
+# `go install` is used instead since it verifies modules via the Go checksum
+# database (GOSUMDB) rather than a hand-rolled release checksum file.
 
 function install_go() {
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -34,8 +40,7 @@ function install_go() {
 function install_golangci_lint() {
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     GOBIN="$(go env GOPATH)/bin"
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-      | sh -s -- -b "$GOBIN"
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
     export PATH="$PATH:$GOBIN"
     if ! grep -q "$GOBIN" ~/.profile 2>/dev/null; then
       echo "export PATH=\"\$PATH:$GOBIN\"" >> ~/.profile

--- a/usage.go
+++ b/usage.go
@@ -11,11 +11,19 @@ func showUsage() {
 	_, _ = fmt.Println("Options:")
 	_, _ = fmt.Println("  --explain, -e     Show examples")
 	_, _ = fmt.Println("  --help, -h        Show this help message")
+	_, _ = fmt.Println("  --version, -v     Show version information")
 	_, _ = fmt.Println("  --update, -u      Automatically update repositories that are behind")
 	_, _ = fmt.Println("  --branch, -b      Specify the branch to check (default: main)")
 	_, _ = fmt.Println("  --log, -l         Show the complete list of changes using git log")
 	_, _ = fmt.Println("  --force, -f       Forcefully abort rebase and merge conflicts to update")
 	_, _ = fmt.Println("  --remote, -r      Remote name (default: origin)")
+	_, _ = fmt.Println()
+	_, _ = fmt.Println("Config file (.rprc) also supports a 'branches' map to override the branch")
+	_, _ = fmt.Println("checked per-repository, keyed by directory name:")
+	_, _ = fmt.Println()
+	_, _ = fmt.Println("  branches:")
+	_, _ = fmt.Println("    repo1: release")
+	_, _ = fmt.Println("    repo2: develop")
 }
 
 // showExamples displays usage with example output.

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package main
+
+// Version is the reporter build version. It defaults to v0.0.1 for local
+// builds (go build, go run) and is overridden at release time via
+// -ldflags "-X main.Version=vX.Y.Z".
+var Version = "v0.0.1"


### PR DESCRIPTION
## Summary
- Add an optional `branches` map to `.rprc` so specific repositories can be checked against a different branch than the global default; an explicit `--branch`/`-b` CLI flag still wins globally.
- Add a `--version`/`-v` flag backed by a build-time-injected `Version` variable (defaults to `v0.0.1` for local builds).
- Rename the misnamed `.github/workflows/release.yml` (actually the CI test workflow) to `ci.yml`, and add a real `release.yml` that cross-builds `rp` for linux/darwin/windows × amd64/arm64 and publishes a GitHub Release (with auto-generated notes) whenever a `v*` tag is pushed.
- Update `README.md` and `--help` output to document both features.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go build -ldflags "-X main.Version=v9.9.9" -o rp . && ./rp --version` prints `v9.9.9`; `go run . --version` (no ldflags) prints `v0.0.1`
- [x] Manually verified per-repo branch override behavior against real local git repos (override applied by default, CLI `--branch` overrides it globally)
- [x] Validated both workflow YAML files parse correctly
- [ ] End-to-end run of the `release.yml` workflow on GitHub Actions (requires pushing a real `v*` tag after merge)