### PR TITLE
Stop auto-generating release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,5 +60,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
           files: artifacts/*

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ git push origin v1.2.3
 ```
 
 This triggers the `Release` GitHub Actions workflow, which cross-builds `rp` for every supported platform and
-publishes a GitHub Release with the binaries attached and auto-generated notes listing the changes since the
-previous release.
+publishes a GitHub Release with the binaries attached. Release notes are **not** auto-generated — add them manually
+by editing the release on GitHub after it's published.
 
 ## Installation
 ### Prerequisites


### PR DESCRIPTION
## Summary
- Remove `generate_release_notes: true` from the release workflow — it was producing duplicated release notes.
- Release notes will be written manually on GitHub after each release is published.
- Update README to reflect that release notes are no longer auto-generated.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Validated `release.yml` still parses as valid YAML